### PR TITLE
modifiy kcrapclient to allow keytab & principal name to be specified

### DIFF
--- a/lib/kcrap.h
+++ b/lib/kcrap.h
@@ -68,6 +68,8 @@ struct kcrap_chal_rep_data
 };
 
 struct kcrap_context *kcrap_init(char *keytab, char *service);
+struct kcrap_context *kcrap_init_princ(char *keytab, char *princ_name);
+struct kcrap_context *kcrap_init_ex(char *keytab, char *service, char *princ_name);
 void kcrap_free(struct kcrap_context *context);
 const char *kcrap_errmsg();
 const struct kcrap_data kcrap_get_extra_data();

--- a/lib/kcraplib.c
+++ b/lib/kcraplib.c
@@ -42,6 +42,16 @@ const struct kcrap_data kcrap_get_extra_data()
 
 struct kcrap_context *kcrap_init(char *keytab, char *service)
 {
+    return kcrap_init_ex(keytab, service, NULL);
+}
+
+struct kcrap_context *kcrap_init_princ(char *keytab, char *princ_name) 
+{
+    return kcrap_init_ex(keytab, NULL, princ_name);
+}
+
+struct kcrap_context *kcrap_init_ex(char *keytab, char *service, char *princ_name)
+{
     struct kcrap_context *context;
     krb5_error_code retval;
     char *names[4];
@@ -68,10 +78,18 @@ struct kcrap_context *kcrap_init(char *keytab, char *service)
         }
 
         /* my princ */
-        if (service == NULL)
-            service = "host";
-        if ((retval = krb5_sname_to_principal(context->krb5_context, NULL, service, KRB5_NT_SRV_HST, &context->sprinc)))
-            break;
+        if (princ_name != NULL) 
+        {
+            if ((retval = krb5_parse_name(context->krb5_context, princ_name, &context->sprinc)))
+                break;
+        }
+        else
+        {
+          if (service == NULL)
+              service = "host";
+          if ((retval = krb5_sname_to_principal(context->krb5_context, NULL, service, KRB5_NT_SRV_HST, &context->sprinc)))
+              break;
+        }
 
         /* Get credentials for server */
         if ((retval = krb5_cc_resolve(context->krb5_context, "MEMORY:kcraplib", &context->ccache)))


### PR DESCRIPTION
Patch that adds (optional) "-p principal name" and "-k keytab" to kcrapclient. I'd been using similar for some years, but completely forgot about it until updating to the latest version.
Without it, there was an error about unable to find principle, and there didn't seem to be anywhere to set it. 
I'm pretty sure it was the same error as in #2, and sounds like the same setup too.

Anyway, if you think it might be of use to others it's here, otherwise if it seems a bit pointless please just close.
